### PR TITLE
Fixed typo on front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ layout: default
 
 
 <main class="content" role="main">
-    <p>This is an <a href="https://github.com/TheLucasMoore/consensual_software">open source project</a> advocating for better use consent in software design.</p>
+    <p>This is an <a href="https://github.com/TheLucasMoore/consensual_software">open source project</a> advocating for better user consent in software design.</p>
 
     <p>Consent is most often discussed in terms of sex. "No means no" is a popular way to teach young people about inappropriate forms of sexual content.</p>
 


### PR DESCRIPTION
I think the front page was supposed to say "for better **user** consent in software", not "use consent". If so, here's a fix :)